### PR TITLE
Fix broken hyperlink & clarify heatmap explanation

### DIFF
--- a/Visualizing_Embeding_for_Prompt_Injection.ipynb
+++ b/Visualizing_Embeding_for_Prompt_Injection.ipynb
@@ -467,7 +467,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The heat map displayed above represents the similarities between various facts, as indexed by the fact numbers from the list we constructed earlier. Each row and column in the heat map corresponds to a specific fact, with the color intensity within each cell indicating the degree of similarity between the facts. Darker or more intense colors signify higher similarity, while lighter colors indicate lesser similarity. This visual tool allows us to quickly discern which facts are more closely related to each other based on their semantic content, enhancing our understanding of the relationships within our dataset."
+    "The heat map displayed above represents the similarities between various facts, as indexed by the fact numbers from the list we constructed earlier. Each row in the heat map corresponds to a specific fact, with the color intensity within each cell indicating the degree of similarity between the facts. Darker or more intense colors signify higher similarity, while lighter colors indicate lesser similarity. This visual tool allows us to quickly discern which facts are more closely related to each other based on their semantic content, enhancing our understanding of the relationships within our dataset."
    ]
   },
   {
@@ -535,7 +535,7 @@
    "source": [
     "Now we are going to use the same concept to find suscpcious prompt injection.\n",
     "\n",
-    "See [this link](https://https://huggingface.co/datasets/deepset/prompt-injections) for more prompt injections ideas\n",
+    "See [this link](https://huggingface.co/datasets/deepset/prompt-injections) for more prompt injections ideas\n",
     "\n",
     "Assume the follwing list contains a full list of known prompt injection"
    ]


### PR DESCRIPTION
The previous version stated that both rows and columns in the heat map correspond to specific facts. This change clarifies the text to indicate that only rows correspond to specific facts (the column corresponds to the `x` or `y` similarity).

Second, it fixes a broken link to the Hugging Face prompt injection data set.